### PR TITLE
Fix $PATH resolution

### DIFF
--- a/discovery.go
+++ b/discovery.go
@@ -43,10 +43,10 @@ func (s *PHPStore) discover() {
 	s.log("Looking for PHP in the PATH (%s)", paths)
 	for _, path := range paths {
 		for _, version := range s.findFromDir(path, nil, "PATH") {
-			idx := s.addVersion(version)
+			s.addVersion(version)
 			// the first one is the default/system PHP binary
 			if s.pathVersion == nil {
-				s.pathVersion = s.versions[idx]
+				s.pathVersion = version
 				s.pathVersion.IsSystem = true
 				s.log("  System PHP version (first in PATH)")
 			}

--- a/store.go
+++ b/store.go
@@ -216,7 +216,7 @@ func (s *PHPStore) loadVersions() {
 }
 
 // addVersion ensures that all versions are unique in the store
-func (s *PHPStore) addVersion(version *Version) int {
+func (s *PHPStore) addVersion(version *Version) {
 	idx, ok := s.seen[version.PHPPath]
 	sl, _ := filepath.EvalSymlinks(version.PHPPath)
 	// double-check to see if that's not just a symlink to another existing version
@@ -230,7 +230,7 @@ func (s *PHPStore) addVersion(version *Version) int {
 		if sl != "" {
 			s.seen[sl] = len(s.versions) - 1
 		}
-		return idx
+		return
 	}
 	currentScore := 0
 	if s.versions[idx].FPMPath != "" {
@@ -247,7 +247,6 @@ func (s *PHPStore) addVersion(version *Version) int {
 	if newScore > currentScore {
 		s.versions[idx] = version
 	}
-	return idx
 }
 
 // versionForDir returns the PHP version to use for a given directory


### PR DESCRIPTION
Because idx has not been updated when adding a version but discovery was relying on it to fetch it from store back, this resulted in getting a version under wrong idx.

Problem has been solved by not getting the version unnecessarily from store but local variable. This made returning the idx from addVersion obsolete.

Ref: https://github.com/NixOS/nixpkgs/issues/228735