### PR TITLE
Add support for Nix

### DIFF
--- a/discovery_others.go
+++ b/discovery_others.go
@@ -24,6 +24,7 @@ package phpstore
 
 import (
 	"bytes"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -64,6 +65,20 @@ func (s *PHPStore) doDiscover() {
 		s.discoverFromDir(prefix, nil, regexp.MustCompile(`^php@(?:[\d\.]+)/(?:[\d\._]+)$`), "homebrew")
 		// pattern example: php/7.2.11
 		s.discoverFromDir(prefix, nil, regexp.MustCompile(`^php/(?:[\d\._]+)$`), "homebrew")
+	}
+
+	// Nix (https://nixos.org/): PHP built with its extensions is stored as
+	// /nix/store/<hash>-php-with-extensions-<version>. Because /nix/store can
+	// hold thousands of unrelated packages, glob the matching entries directly
+	// instead of walking the whole tree.
+	if dirs, err := filepath.Glob("/nix/store/*-php-with-extensions-*"); err == nil {
+		for _, dir := range dirs {
+			// skip .drv files and any other non-directory matches
+			if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
+				continue
+			}
+			s.addFromDir(dir, nil, "Nix")
+		}
 	}
 
 	if runtime.GOOS == "darwin" {


### PR DESCRIPTION
Before this change, the Symfony CLI was not able to find all PHP versions I installed on my machine through Nix.

With this PR, all my PHP versions are now correctly discovered:
```
symfony-cli on  main via 🐳 orbstack via 🐹 v1.26.4 took 2s
➜ go build

symfony-cli on  main via 🐳 orbstack via 🐹 v1.26.4
➜ ./symfony-cli local:php:list
+---------+------------------------------------------------------------------------+---------+-------------+-------------+---------+---------+
| Version |                               Directory                                |   PHP   |     PHP     |     PHP     | Server  | System? |
|         |                                                                        |   CLI   |     FPM     |     CGI     |         |         |
+---------+------------------------------------------------------------------------+---------+-------------+-------------+---------+---------+
| 8.1.34  | /nix/store/0b124alj3m71nj2kz4mvh3yph729g45f-php-with-extensions-8.1.34 | bin/php | bin/php-fpm | bin/php-cgi | PHP FPM |         |
| 8.2.31  | /nix/store/h4q20jqavc40gcy8nlxn7r826b15cmy6-php-with-extensions-8.2.31 | bin/php | bin/php-fpm | bin/php-cgi | PHP FPM |         |
| 8.3.31  | /nix/store/xxzf9zv1rv95bjjmbrdkc2hyb3h4lb31-php-with-extensions-8.3.31 | bin/php | bin/php-fpm | bin/php-cgi | PHP FPM |         |
| 8.4.22  | /nix/store/d8wzkxvwhp0vd8aizgrk8aq0cykcsgik-php-with-extensions-8.4.22 | bin/php | bin/php-fpm | bin/php-cgi | PHP FPM | *       |
| 8.5.7   | /nix/store/7grs0mlr1nxjxjmw5iyk3mqpfsr7lwi6-php-with-extensions-8.5.7  | bin/php | bin/php-fpm | bin/php-cgi | PHP FPM |         |
+---------+------------------------------------------------------------------------+---------+-------------+-------------+---------+---------+
```
